### PR TITLE
Move Span to heap to optimize memory layout

### DIFF
--- a/sdml-core/src/model/annotations.rs
+++ b/sdml-core/src/model/annotations.rs
@@ -325,7 +325,7 @@ pub enum Annotation {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct AnnotationProperty {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name_reference: IdentifierReference,
     value: Value,
 }
@@ -335,7 +335,7 @@ pub struct AnnotationProperty {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct AnnotationOnlyBody {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     annotations: Vec<Annotation>, // assert!(!annotations.is_empty());
 }
 

--- a/sdml-core/src/model/constraints/formal/environments.rs
+++ b/sdml-core/src/model/constraints/formal/environments.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EnvironmentDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     body: EnvironmentDefBody,
 }

--- a/sdml-core/src/model/constraints/formal/functions.rs
+++ b/sdml-core/src/model/constraints/formal/functions.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FunctionDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     signature: FunctionSignature,
     body: ConstraintSentence,
 }
@@ -29,7 +29,7 @@ pub struct FunctionDef {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FunctionSignature {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     parameters: Vec<FunctionParameter>,
     target_type: FunctionType,
 }
@@ -38,7 +38,7 @@ pub struct FunctionSignature {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FunctionParameter {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     target_type: FunctionType,
 }
@@ -47,7 +47,7 @@ pub struct FunctionParameter {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FunctionType {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     target_cardinality: FunctionCardinality,
     target_type: FunctionTypeReference,
 }
@@ -57,7 +57,7 @@ pub struct FunctionType {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FunctionCardinality {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     ordering: Option<Ordering>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -333,7 +333,7 @@ impl FunctionCardinality {
     // Fields
     // --------------------------------------------------------------------------------------------
 
-    pub const fn with_ordering(self, ordering: Ordering) -> Self {
+    pub fn with_ordering(self, ordering: Ordering) -> Self {
         Self {
             ordering: Some(ordering),
             ..self
@@ -350,7 +350,7 @@ impl FunctionCardinality {
     // --------------------------------------------------------------------------------------------
 
     #[inline(always)]
-    pub const fn with_uniqueness(self, uniqueness: Uniqueness) -> Self {
+    pub fn with_uniqueness(self, uniqueness: Uniqueness) -> Self {
         Self {
             uniqueness: Some(uniqueness),
             ..self

--- a/sdml-core/src/model/constraints/formal/mod.rs
+++ b/sdml-core/src/model/constraints/formal/mod.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FormalConstraint {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
     environment: Vec<EnvironmentDef>,
     body: ConstraintSentence,

--- a/sdml-core/src/model/constraints/formal/sentences.rs
+++ b/sdml-core/src/model/constraints/formal/sentences.rs
@@ -63,7 +63,7 @@ pub enum SimpleSentence {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct AtomicSentence {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     predicate: Term,
     arguments: Vec<Term>,
 }
@@ -72,7 +72,7 @@ pub struct AtomicSentence {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Equation {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     left_operand: Term,
     right_operand: Term,
 }
@@ -81,7 +81,7 @@ pub struct Equation {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Inequation {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     left_operand: Term,
     relation: InequalityRelation,
     right_operand: Term,
@@ -119,7 +119,7 @@ pub enum BooleanSentence {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct UnaryBooleanSentence {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     operand: Box<ConstraintSentence>,
 }
 
@@ -131,7 +131,7 @@ pub struct UnaryBooleanSentence {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct BinaryBooleanSentence {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     left_operand: Box<ConstraintSentence>,
     operator: ConnectiveOperator,
     right_operand: Box<ConstraintSentence>,
@@ -170,7 +170,7 @@ pub enum ConnectiveOperator {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct QuantifiedSentence {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     binding: QuantifiedVariableBinding,
     body: Box<ConstraintSentence>,
 }
@@ -179,7 +179,7 @@ pub struct QuantifiedSentence {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct QuantifiedVariableBinding {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     quantifier: Quantifier,
     // None = `self`
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -206,7 +206,7 @@ pub enum Quantifier {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct QuantifiedVariable {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     source: Term,
 }

--- a/sdml-core/src/model/constraints/formal/sequences.rs
+++ b/sdml-core/src/model/constraints/formal/sequences.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct SequenceBuilder {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     variables: Variables,
     body: QuantifiedSentence,
 }
@@ -29,7 +29,7 @@ pub enum Variables {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct NamedVariables {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     names: HashSet<Identifier>,
 }
 
@@ -37,7 +37,7 @@ pub struct NamedVariables {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct MappingVariable {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     domain: Identifier,
     range: Identifier,
 }

--- a/sdml-core/src/model/constraints/formal/terms.rs
+++ b/sdml-core/src/model/constraints/formal/terms.rs
@@ -44,7 +44,7 @@ pub enum Term {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FunctionComposition {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     subject: Subject,                // assert!(!is_empty())
     function_names: Vec<Identifier>, // ditto
 }
@@ -63,7 +63,7 @@ pub enum Subject {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FunctionalTerm {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     function: Term,
     arguments: Vec<Term>,
 }

--- a/sdml-core/src/model/constraints/formal/values.rs
+++ b/sdml-core/src/model/constraints/formal/values.rs
@@ -21,7 +21,7 @@ pub enum PredicateValue {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct SequenceOfPredicateValues {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     values: Vec<PredicateSequenceMember>,
 }
 

--- a/sdml-core/src/model/constraints/informal.rs
+++ b/sdml-core/src/model/constraints/informal.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ControlledLanguageString {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     /// Corresponds to the grammar rule `quoted_string`.
     value: String,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -65,7 +65,7 @@ pub struct ControlledLanguageString {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ControlledLanguageTag {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     value: String,
 }
 

--- a/sdml-core/src/model/constraints/mod.rs
+++ b/sdml-core/src/model/constraints/mod.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Constraint {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     body: ConstraintBody,
 }

--- a/sdml-core/src/model/definitions/classes.rs
+++ b/sdml-core/src/model/definitions/classes.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TypeClassDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
     variables: Vec<TypeVariable>, // assert 1..
@@ -43,7 +43,7 @@ pub struct TypeClassDef {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TypeVariable {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     cardinality: Option<FunctionCardinality>,
@@ -56,7 +56,7 @@ pub struct TypeVariable {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TypeClassReference {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: IdentifierReference,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
     arguments: Vec<TypeClassArgument>, // 0..
@@ -75,7 +75,7 @@ pub enum TypeClassArgument {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TypeClassBody {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
     annotations: Vec<Annotation>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
@@ -87,7 +87,7 @@ pub struct TypeClassBody {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct MethodDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     signature: FunctionSignature,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]

--- a/sdml-core/src/model/definitions/datatypes.rs
+++ b/sdml-core/src/model/definitions/datatypes.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct DatatypeDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     opaque: bool,
     /// Corresponds to the grammar rule `data_type_base`.
@@ -96,7 +96,7 @@ impl Validate for DatatypeDef {
             loader
                 .report(&type_definition_not_found(
                     top.file_id().copied().unwrap_or_default(),
-                    self.span.as_ref().map(|span| span.into()),
+                    self.span.as_ref().map(|span| span.as_ref().into()),
                     self.base_type(),
                 ))
                 .unwrap();

--- a/sdml-core/src/model/definitions/entities.rs
+++ b/sdml-core/src/model/definitions/entities.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EntityDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     body: Option<EntityBody>,
@@ -36,7 +36,7 @@ pub struct EntityDef {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EntityBody {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     identity: Member,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
     annotations: Vec<Annotation>,

--- a/sdml-core/src/model/definitions/enums.rs
+++ b/sdml-core/src/model/definitions/enums.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EnumDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     body: Option<EnumBody>,
@@ -37,7 +37,7 @@ pub struct EnumDef {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EnumBody {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
     annotations: Vec<Annotation>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
@@ -49,7 +49,7 @@ pub struct EnumBody {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ValueVariant {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     body: Option<AnnotationOnlyBody>,

--- a/sdml-core/src/model/definitions/events.rs
+++ b/sdml-core/src/model/definitions/events.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EventDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     event_source: IdentifierReference,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]

--- a/sdml-core/src/model/definitions/properties.rs
+++ b/sdml-core/src/model/definitions/properties.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct PropertyDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     member: MemberDef,
 }
 

--- a/sdml-core/src/model/definitions/rdf.rs
+++ b/sdml-core/src/model/definitions/rdf.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct RdfDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     body: AnnotationOnlyBody,
 }

--- a/sdml-core/src/model/definitions/structures.rs
+++ b/sdml-core/src/model/definitions/structures.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct StructureDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     body: Option<StructureBody>,
@@ -32,7 +32,7 @@ pub struct StructureDef {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct StructureBody {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
     annotations: Vec<Annotation>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]

--- a/sdml-core/src/model/definitions/unions.rs
+++ b/sdml-core/src/model/definitions/unions.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct UnionDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     body: Option<UnionBody>,
@@ -36,7 +36,7 @@ pub struct UnionDef {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct UnionBody {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
     annotations: Vec<Annotation>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty"))]
@@ -48,7 +48,7 @@ pub struct UnionBody {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TypeVariant {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name_reference: IdentifierReference,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     rename: Option<Identifier>,

--- a/sdml-core/src/model/identifiers.rs
+++ b/sdml-core/src/model/identifiers.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Identifier {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     value: String,
 }
 
@@ -42,7 +42,7 @@ pub struct Identifier {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct QualifiedIdentifier {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     module: Identifier,
     member: Identifier,
 }
@@ -206,7 +206,7 @@ impl Identifier {
             loader
                 .report(&invalid_identifier(
                     top.file_id().copied().unwrap_or_default(),
-                    self.span.map(|s| s.into()),
+                    self.span.as_ref().map(|s| s.as_ref().into()),
                     &self.value,
                 ))
                 .unwrap();

--- a/sdml-core/src/model/macros.rs
+++ b/sdml-core/src/model/macros.rs
@@ -15,16 +15,19 @@ macro_rules! impl_has_source_span_for {
        impl $crate::model::HasSourceSpan for $type {
             fn with_source_span(self, span: $crate::model::Span) -> Self {
                 let mut self_mut = self;
-                self_mut.span = Some(span);
+                self_mut.span = Some(Box::new(span));
                 self_mut
             }
 
             fn source_span(&self) -> Option<&$crate::model::Span> {
-                self.$inner.as_ref()
+                match &self.$inner {
+                    Some(v) => Some(v.as_ref()),
+                    None => None,
+                }
             }
 
             fn set_source_span(&mut self, span: $crate::model::Span) {
-                self.$inner = Some(span);
+                self.$inner = Some(Box::new(span));
             }
 
             fn unset_source_span(&mut self) {

--- a/sdml-core/src/model/members/mod.rs
+++ b/sdml-core/src/model/members/mod.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Member {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     kind: MemberKind,
 }
 
@@ -45,7 +45,7 @@ pub enum MemberKind {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct MemberDef {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     name: Identifier,
     target_cardinality: Cardinality,
     target_type: TypeReference,

--- a/sdml-core/src/model/members/types.rs
+++ b/sdml-core/src/model/members/types.rs
@@ -58,7 +58,7 @@ pub enum TypeReference {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct MappingType {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     domain: Box<TypeReference>,
     range: Box<TypeReference>,
 }

--- a/sdml-core/src/model/values.rs
+++ b/sdml-core/src/model/values.rs
@@ -66,7 +66,7 @@ pub struct Binary(Vec<u8>);
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct LanguageString {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     /// Corresponds to the grammar rule `quoted_string`.
     value: String,
     language: Option<LanguageTag>,
@@ -77,7 +77,7 @@ pub struct LanguageString {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct LanguageTag {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     value: language_tags::LanguageTag,
 }
 
@@ -86,7 +86,7 @@ pub struct LanguageTag {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct MappingValue {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     domain: SimpleValue,
     range: Box<Value>,
 }
@@ -96,7 +96,7 @@ pub struct MappingValue {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct SequenceOfValues {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     ordering: Option<Ordering>,
     uniqueness: Option<Uniqueness>,
     values: Vec<SequenceMember>,
@@ -117,7 +117,7 @@ pub enum SequenceMember {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ValueConstructor {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    span: Option<Span>,
+    span: Option<Box<Span>>,
     type_name: IdentifierReference,
     value: SimpleValue,
 }

--- a/sdml-generate/tests/common.rs
+++ b/sdml-generate/tests/common.rs
@@ -110,7 +110,7 @@ macro_rules! test_example {
 
                 let result_string = $transform(module, &cache);
 
-                crate::common::verify_example_output(&result_string, &expected);
+                $crate::common::verify_example_output(&result_string, &expected);
             }
         }
     };

--- a/sdml-parse/src/parse/members/mod.rs
+++ b/sdml-parse/src/parse/members/mod.rs
@@ -68,7 +68,7 @@ pub(crate) fn parse_cardinality_expression<'a>(
             })?;
             Cardinality::new_range(min, max)
         } else {
-            Cardinality::new_unbounded(min)
+            Cardinality::new_unbounded(min, None, None)
         }
     } else {
         Cardinality::new_single(min)


### PR DESCRIPTION
This PR resolves the issue showed here: https://github.com/sdm-lang/rust-sdml/actions/runs/12957873989/job/36147087568

I was thinking whether the right approach is to do boxing in the enums as it reports, but I found out that the main issue is that the `Span` has added significant footprint of the memory (it tripled in size). Boxing other values would mean using heap for almost everything, while boxing just `Span` allows us to use heap only when creating the tree and when accessing the span. 

The good part is that I was able to do search and replace for the `Span` member creation, fix the macro and the rest are relatively tiny touches that were needed to make the compiler happy. I haven't found any of them controversial, but for example you can notice that `const` method cannot drop structure with a heap property (see cardinality). So, I have updated the constructor methods to accept all arguments for arrays to be able to use them in `const`, the builder-like interface cannot be done using const functions.