### PR TITLE
Fix typos

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,7 @@
 [files]
 extend-exclude = ["*/data/*"]
+
+[default]
+extend-ignore-re = [
+  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"
+]

--- a/sdml-core/README.md
+++ b/sdml-core/README.md
@@ -131,7 +131,7 @@ or convert into s-expressions, etc.
   - Remove `base` keyword.
   - Add new optional `version` keyword after module URI with:
     - optional version string that becomes `owl:versionInfo`.
-    - version URI that becomes `owl:verionIRI`.
+    - version URI that becomes `owl:versionIRI`.
 - Feature: Add new RDF structure/property definitions.
   - Add new keyword `rdf` followed by either =structure= or =property= with name and annotation body.
   - Extended `SimpleModuleWalker` with support for RDF class/property definitions.

--- a/sdml-core/src/model/identifiers.rs
+++ b/sdml-core/src/model/identifiers.rs
@@ -63,7 +63,7 @@ pub enum IdentifierReference {
 
 lazy_static! {
     static ref IDENTIFIER: Regex =
-        Regex::new(r"^[\p{Lu}\p{Ll}][\p{Lu}\p{Ll}\p{Nd}]*(?:_+[\p{Lu}\p{Ll}\p{Nd}]+)*$").unwrap();
+        Regex::new(r"^[\p{Lu}\p{Ll}][\p{Lu}\p{Ll}\p{Nd}]*(?:_+[\p{Lu}\p{Ll}\p{Nd}]+)*$").unwrap(); // spellchecker:disable-line
 }
 
 const RESERVED_KEYWORDS: [&str; 19] = [

--- a/sdml-core/src/model/walk.rs
+++ b/sdml-core/src/model/walk.rs
@@ -576,7 +576,7 @@ pub trait SimpleModuleVisitor {
     }
 
     ///
-    /// Called to denote the start of a `TypeVarian` instance.
+    /// Called to denote the start of a `TypeVariant` instance.
     ///
     /// # Nested
     ///

--- a/sdml-core/src/stdlib/skos.rs
+++ b/sdml-core/src/stdlib/skos.rs
@@ -139,7 +139,7 @@ pairwise disjoint properties."@en))
             .with_predicate(
                 id!(EXAMPLE),
                 lstr!("Acronyms, abbreviations, spelling variants, and irregular plural/singular
-forms may be included among the alternative labels for a concept. Mis-spelled terms are normally
+forms may be included among the alternative labels for a concept. Misspelled terms are normally
  included as hidden labels (see skos:hiddenLabel)"@en)
             )
             .into(),

--- a/sdml-core/src/syntax.rs
+++ b/sdml-core/src/syntax.rs
@@ -311,8 +311,8 @@ pub const PC_BINARY_START: &str = "#[";
 pub const PC_CARDINALITY_END: &str = "}";
 pub const PC_CARDINALITY_START: &str = "{";
 
-pub const PC_CONSTRAINT_EXRESSION_GROUP_END: &str = ")";
-pub const PC_CONSTRAINT_EXRESSION_GROUP_START: &str = "(";
+pub const PC_CONSTRAINT_EXPRESSION_GROUP_END: &str = ")";
+pub const PC_CONSTRAINT_EXPRESSION_GROUP_START: &str = "(";
 
 pub const PC_FUNCTION_COMPOSITION_SEPARATOR: &str = ".";
 

--- a/sdml-generate/src/draw/uml.rs
+++ b/sdml-generate/src/draw/uml.rs
@@ -210,7 +210,7 @@ package "{name}" as {} <<module>> {{
             .draw_definition_named(DefinitionKind::Datatype, name)
         {
             self.buffer
-                .push_str(&start_type_with_sterotype("class", name, "datatype"));
+                .push_str(&start_type_with_stereotype("class", name, "datatype"));
 
             // TODO: add opaque as stereotype on restriction
 
@@ -253,7 +253,7 @@ package "{name}" as {} <<module>> {{
             .content_filter
             .draw_definition_named(DefinitionKind::Entity, name)
         {
-            self.buffer.push_str(&start_type_with_sterotype(
+            self.buffer.push_str(&start_type_with_stereotype(
                 if entity.has_body() {
                     "class"
                 } else {
@@ -282,7 +282,7 @@ package "{name}" as {} <<module>> {{
             .draw_definition_named(DefinitionKind::Enum, name)
         {
             self.buffer
-                .push_str(&start_type_with_sterotype("class", an_enum.name(), "enum"));
+                .push_str(&start_type_with_stereotype("class", an_enum.name(), "enum"));
         }
         Self::INCLUDE_NESTED
     }
@@ -303,7 +303,7 @@ package "{name}" as {} <<module>> {{
         {
             let source = event.event_source();
             self.buffer
-                .push_str(&start_type_with_sterotype("class", name, "event"));
+                .push_str(&start_type_with_stereotype("class", name, "event"));
             self.assoc_src = Some(name.to_string());
             let reference = format!("  {} ..> {}: <<source>>\n", make_id(name), make_id(source));
             self.refs = Some(
@@ -330,8 +330,11 @@ package "{name}" as {} <<module>> {{
             .content_filter
             .draw_definition_named(DefinitionKind::Enum, defn.name())
         {
-            self.buffer
-                .push_str(&start_type_with_sterotype("class", defn.name(), "property"));
+            self.buffer.push_str(&start_type_with_stereotype(
+                "class",
+                defn.name(),
+                "property",
+            ));
         }
         Self::INCLUDE_NESTED
     }
@@ -351,7 +354,7 @@ package "{name}" as {} <<module>> {{
             .draw_definition_named(DefinitionKind::Enum, name)
         {
             self.buffer
-                .push_str(&start_type_with_sterotype("class", name, "structure"));
+                .push_str(&start_type_with_stereotype("class", name, "structure"));
             self.assoc_src = Some(name.to_string());
         }
         Self::INCLUDE_NESTED
@@ -372,7 +375,7 @@ package "{name}" as {} <<module>> {{
             .draw_definition_named(DefinitionKind::Enum, name)
         {
             self.buffer
-                .push_str(&start_type_with_sterotype("class", name, "rdf"));
+                .push_str(&start_type_with_stereotype("class", name, "rdf"));
             self.assoc_src = Some(name.to_string());
         }
         Self::INCLUDE_NESTED
@@ -392,7 +395,7 @@ package "{name}" as {} <<module>> {{
             .draw_definition_named(DefinitionKind::Enum, name)
         {
             self.buffer
-                .push_str(&start_type_with_sterotype("class", name, "union"));
+                .push_str(&start_type_with_stereotype("class", name, "union"));
             self.assoc_src = Some(name.to_string());
         }
         Self::INCLUDE_NESTED
@@ -510,7 +513,7 @@ where
     format!("s_{}", id.into().replace(':', "__"))
 }
 
-fn start_type_with_sterotype(
+fn start_type_with_stereotype(
     type_class: &str,
     type_name: &Identifier,
     stereo_name: &str,


### PR DESCRIPTION
I was not able to figure out how to suppress typos on individual lines. Are you aware of a way how to do it? The regexes are fine, but don't want to disable it for the whole file.